### PR TITLE
[Bugfix] BE-12 검색어에 null 이 들어감

### DIFF
--- a/src/main/java/com/price/search/howmuchisit/domain/search/service/SearchService.java
+++ b/src/main/java/com/price/search/howmuchisit/domain/search/service/SearchService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -40,8 +41,8 @@ public class SearchService {
     }
 
     private String createSearchQuery(SearchRequest request) {
-        return request.getBrand() +
-                request.getTitle() +
-                request.getAmount();
+        return Optional.ofNullable(request.getBrand()).orElse("") +
+                Optional.ofNullable(request.getTitle()).orElse("") +
+                Optional.ofNullable(request.getAmount()).orElse("");
     }
 }


### PR DESCRIPTION
#[Bugfix] BE-12 검색어에 null 이 들어감
https://www.notion.so/cudy/BE-12-null-781a5e992d0f4ab08f101d12c1885774?pvs=4
## 작업내용
- string concat 에 null -> empty string 으로 치환
## 변경내용