### PR TITLE
[bugfix] BE-14 JPA metamodel must not be empty! 에러

### DIFF
--- a/src/main/java/com/price/search/howmuchisit/HowMuchIsItApplication.java
+++ b/src/main/java/com/price/search/howmuchisit/HowMuchIsItApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class HowMuchIsItApplication {
 

--- a/src/main/java/com/price/search/howmuchisit/common/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/price/search/howmuchisit/common/config/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.price.search.howmuchisit.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/test/java/com/price/search/howmuchisit/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/price/search/howmuchisit/domain/search/service/SearchServiceTest.java
@@ -4,6 +4,7 @@ import com.price.search.howmuchisit.domain.naver.dto.NaverItem;
 import com.price.search.howmuchisit.domain.naver.service.NaverSearchService;
 import com.price.search.howmuchisit.domain.search.dto.SearchRequest;
 import com.price.search.howmuchisit.domain.search.dto.SearchResponse;
+import com.price.search.howmuchisit.domain.search.repository.SearchLogRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,6 +22,9 @@ class SearchServiceTest {
 
     @Mock
     private NaverSearchService naverSearchService;
+
+    @Mock
+    private SearchLogRepository searchLogRepository;
 
     @InjectMocks
     private SearchService searchService;
@@ -54,6 +58,8 @@ class SearchServiceTest {
         );
         when(naverSearchService.searchItems(anyString()))
                 .thenReturn(naverItems);
+        when(searchLogRepository.save(any()))
+                .thenReturn(null);
 
         // Act
         List<SearchResponse> searchResponses = searchService.search(request);


### PR DESCRIPTION
# [bugfix] BE-14 JPA metamodel must not be empty! 에러
https://www.notion.so/cudy/BE-14-JPA-metamodel-must-not-be-empty-93cc66026b2c463fb0b6f092094a89bf?pvs=4
## 작업내용
`@EnableJpaAuditing` 별도 파일로 빼냄

## 변경로직